### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/User2200/eba4be79-291f-4493-a730-9e7ca3eebe2d/f26ab62b-ebce-484a-9c8c-b037a47ba198/_apis/work/boardbadge/446fbd7c-7241-462d-8a81-b6e0a607dcef)](https://dev.azure.com/User2200/eba4be79-291f-4493-a730-9e7ca3eebe2d/_boards/board/t/f26ab62b-ebce-484a-9c8c-b037a47ba198/Microsoft.RequirementCategory)
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#420](https://dev.azure.com/User2200/eba4be79-291f-4493-a730-9e7ca3eebe2d/_workitems/edit/420). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.